### PR TITLE
Only return campaign metrics that have eligible deployments

### DIFF
--- a/manage/app/routes/email/campaign-metrics.js
+++ b/manage/app/routes/email/campaign-metrics.js
@@ -33,6 +33,7 @@ export default Route.extend(ListRouteMixin, {
     const input = {
       customerIds: customers.map((customer) => customer.id),
       mustHaveEmailEnabled: true,
+      mustHaveEmailDeployments: true,
       dateRange: {
         start: rangeStart.valueOf(),
         end: rangeEnd.valueOf(),

--- a/monorepo/services/server/src/graphql/definitions/campaign.js
+++ b/monorepo/services/server/src/graphql/definitions/campaign.js
@@ -230,6 +230,7 @@ input AllCampaignsQueryInput {
   ending: CampaignDateFilterInput = {}
   dateRange: AllCampaignsQueryDateRangeInput
   mustHaveEmailEnabled: Boolean
+  mustHaveEmailDeployments: Boolean = false
 }
 
 input AllCampaignsQueryDateRangeInput {

--- a/monorepo/services/server/src/services/email-report.js
+++ b/monorepo/services/server/src/services/email-report.js
@@ -1,5 +1,6 @@
 const escapeRegex = require('escape-string-regexp');
 const {
+  Campaign,
   Customer,
   ExcludedEmailDomain,
   ExtractedUrl,
@@ -143,6 +144,18 @@ module.exports = {
       o.deploymentEntities.push(deployment.entity);
       return o;
     }, { urlIds: [], deploymentEntities: [] });
+  },
+
+  async getCampaignIdsWithDeployments(criteria, { starting, ending } = {}) {
+    const campaigns = await Campaign.find(criteria);
+    const campaignIds = await Promise.all(campaigns.map(async (campaign) => {
+      const { deploymentEntities } = await this.getEligibleUrlsAndDeployments(campaign, {
+        starting,
+        ending,
+      });
+      return deploymentEntities.length ? campaign._id : null;
+    }));
+    return campaignIds.filter((id) => id);
   },
 
   /**


### PR DESCRIPTION
When viewing email campaign metrics, only return campaigns that have email deployments that match the provided date range