### PR TITLE
Change `lt.*` query params to `__lt-*`

### DIFF
--- a/monorepo/packages/migrate/transformers/extracted-hosts.js
+++ b/monorepo/packages/migrate/transformers/extracted-hosts.js
@@ -12,7 +12,7 @@ const unqiueUrlParams = (doc) => {
   }, new Map());
 
   if (isOwnedSite(hostname)) {
-    paramMap.set('lt.usr', '@{encrypted_customer_id}@');
+    paramMap.set('__lt-usr', '@{encrypted_customer_id}@');
     paramMap.set('utm_source', '@{track_id}@');
     paramMap.set('utm_medium', 'email');
     paramMap.set('utm_campaign', '@{mv_date_MMddyyyy}@');

--- a/monorepo/packages/sync/utils/extract-url-id.js
+++ b/monorepo/packages/sync/utils/extract-url-id.js
@@ -1,6 +1,7 @@
 const patterns = [
   /lt\.lid=([a-f0-9]{24})/,
   /&lt;\.lid=([a-f0-9]{24})/,
+  /__lt-lid=([a-f0-9]{24})/,
 ];
 
 /**

--- a/monorepo/services/server/src/services/html-link-injector.js
+++ b/monorepo/services/server/src/services/html-link-injector.js
@@ -257,6 +257,20 @@ module.exports = {
         return null;
       }
     }
+    const match4 = /lt\.lid=([a-f0-9]{24})/i.exec(clean);
+    if (match4 && match4[1]) return match4[1];
+
+    const match5 = /__lt-lid=([a-f0-9]{24})/i.exec(clean);
+    if (match5 && match5[1]) return match5[1];
+
+    const match6 = /%3C\.lid=([a-f0-9]{24})/i.exec(clean);
+    if (match6 && match6[1]) return match6[1];
+
+    const match7 = /&lt;\.lid=([a-f0-9]{24})/i.exec(clean);
+    if (match7 && match7[1]) return match7[1];
+
+    const match8 = /<\.lid=([a-f0-9]{24})/i.exec(clean);
+    if (match8 && match8[1]) return match8[1];
     return null;
   },
 

--- a/monorepo/services/server/src/services/html-link-injector.js
+++ b/monorepo/services/server/src/services/html-link-injector.js
@@ -62,7 +62,7 @@ module.exports = {
     const params = new URLSearchParams(parsed.searchParams);
 
     // Inject the link ID on all URLs.
-    params.set('lt.lid', id);
+    params.set('__lt-lid', id);
 
     // Get parameters to inject.
     const injectParams = await UrlManager.getMergedUrlParams(url);

--- a/monorepo/services/server/src/services/url-manager.js
+++ b/monorepo/services/server/src/services/url-manager.js
@@ -118,7 +118,7 @@ module.exports = {
     }, new Map());
 
     if (isInternalUrl(value)) {
-      map.set('lt.usr', '@{encrypted_customer_id}@');
+      map.set('__lt-usr', '@{encrypted_customer_id}@');
       map.set('utm_source', '@{track_id}@');
       map.set('utm_medium', 'email');
       map.set('utm_campaign', '@{mv_date_MMddyyyy}@');


### PR DESCRIPTION
Prevents issues with `&lt` params being interpreted as HTML entities