### PR TITLE
Add email deployment toggle to campaign metrics

### DIFF
--- a/manage/app/controllers/email/campaign-metrics.js
+++ b/manage/app/controllers/email/campaign-metrics.js
@@ -36,6 +36,9 @@ export default ListController.extend({
     this.get('queryParams').pushObject('customers');
     this.get('queryParams').pushObject('rangeStart');
     this.get('queryParams').pushObject('rangeEnd');
+    this.get('queryParams').pushObject('mustHaveEmailDeployments');
+
+    this.set('mustHaveEmailDeployments', false);
 
     this.set('customers', []);
     const now = new Date();
@@ -74,6 +77,10 @@ export default ListController.extend({
       if (!end) return;
       this.set('rangeStart', start);
       this.set('rangeEnd', end);
+    },
+
+    setMustHaveEmailDeployments(event) {
+      this.set('mustHaveEmailDeployments', event.target.checked);
     },
 
     clearFilters() {

--- a/manage/app/routes/email/campaign-metrics.js
+++ b/manage/app/routes/email/campaign-metrics.js
@@ -33,7 +33,7 @@ export default Route.extend(ListRouteMixin, {
     const input = {
       customerIds: customers.map((customer) => customer.id),
       mustHaveEmailEnabled: true,
-      mustHaveEmailDeployments: true,
+      mustHaveEmailDeployments: false,
       dateRange: {
         start: rangeStart.valueOf(),
         end: rangeEnd.valueOf(),

--- a/manage/app/routes/email/campaign-metrics.js
+++ b/manage/app/routes/email/campaign-metrics.js
@@ -9,6 +9,7 @@ export default Route.extend(ListRouteMixin, {
     this.set('queryParams.customers', { refreshModel: true });
     this.set('queryParams.rangeStart', { refreshModel: true });
     this.set('queryParams.rangeEnd', { refreshModel: true });
+    this.set('queryParams.mustHaveEmailDeployments', { refreshModel: true });
   },
 
   beforeModel(transition) {
@@ -29,11 +30,12 @@ export default Route.extend(ListRouteMixin, {
     customers,
     rangeStart,
     rangeEnd,
+    mustHaveEmailDeployments,
   }) {
     const input = {
       customerIds: customers.map((customer) => customer.id),
       mustHaveEmailEnabled: true,
-      mustHaveEmailDeployments: false,
+      mustHaveEmailDeployments,
       dateRange: {
         start: rangeStart.valueOf(),
         end: rangeEnd.valueOf(),

--- a/manage/app/templates/email/campaign-metrics.hbs
+++ b/manage/app/templates/email/campaign-metrics.hbs
@@ -42,6 +42,17 @@
                     </div>
                   </div>
 
+                  <div class="row">
+                    <div class="col">
+                      <div class="form-group">
+                        <div class="custom-control custom-checkbox">
+                          {{input type="checkbox" checked=mustHaveEmailDeployments class="custom-control-input" id="must-have-email-deployments" change=(action "setMustHaveEmailDeployments")}}
+                          <label class="custom-control-label" for="must-have-email-deployments">Campaigns must have email deployments</label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
                 </div>
                 <div class="card-footer d-flex justify-content-end">
                   <button class="btn btn-primary" disabled={{clearButtonDisabled}} {{action "clearFilters"}}>Reset All</button>


### PR DESCRIPTION
The `mustHaveEmailDeployments` flag is now set to `false` by default, but can be changed by checking the option under the Filters button.

Filter
![image](https://user-images.githubusercontent.com/3289485/145442710-c6335775-a9cd-4b77-88e8-0fdfe7c7c090.png)

When disabled (default):
![image](https://user-images.githubusercontent.com/3289485/145442813-e659ec62-ef60-461f-9db2-b082ef5af335.png)

When enabled:
![image](https://user-images.githubusercontent.com/3289485/145442864-29198099-c90a-4e07-aa84-d43a9a91d7e5.png)

