### PR TITLE
Disable strictSSL option for crawling urls

### DIFF
--- a/monorepo/services/server/src/services/url-manager.js
+++ b/monorepo/services/server/src/services/url-manager.js
@@ -23,6 +23,7 @@ const doNotScrape = ['.pdf'].reduce((map, ext) => {
 
 const crawl = (url) => Juicer.crawler.crawl(url, {
   jar: true,
+  strictSSL: false, // Allow potentially invalid SSL chains to still be followed.
   headers: {
     Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',


### PR DESCRIPTION
Uses the `strictSSL` option of the underlying `request` library to allow insecure URLs to be followed. In this case, one of the servers for a client URL does not properly support SNI and does not return an intermediate certificate. In most browsers, this is fine, but in the request library this is an error.