### PR TITLE
Set dev resources to Mongo 3.6; disable upsert on ping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,17 +43,17 @@ x-tenant-env: &tenant-env
 services:
   google-ad-manager:
     tty: true
-    image: parameter1/google-ad-manager-graphql-service:v1.0.0
+    image: parameter1/google-ad-manager-graphql-service:v1.1.0
     volumes:
       - ./service-account.json:/service-account.json
     environment:
       JSON_KEY_FILE_PATH: /service-account.json
       NETWORK_CODE: 137873098
-      VERSION: v202105
+      VERSION: v202205
 
   mongo:
     tty: true
-    image: mongo:3.4
+    image: mongo:3.6
     restart: always
     volumes:
       - mongodb:/data/db

--- a/monorepo/services/server/src/index.js
+++ b/monorepo/services/server/src/index.js
@@ -18,10 +18,7 @@ process.on('unhandledRejection', (e) => {
   throw e;
 });
 
-const pingMongo = () => Promise.all([
-  mongoose.db.command({ ping: 1 }),
-  mongoose.db.collection('pings').updateOne({ _id: pkg.name }, { $set: { last: new Date() } }, { upsert: true }),
-]);
+const pingMongo = () => mongoose.db.command({ ping: 1 });
 
 bootService({
   name: pkg.name,


### PR DESCRIPTION
The upsert on ping is being disabled to prevent the restore from failing due to the ping recreating the collection while running