### PR TITLE
Alter unique email domains logic/language

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@
 - [x] test new ad click/impression trackers
 - [x] add meta tags to website for scraping companies/tags
 - [x] do not cache indm websites when crawling
+
+## Onboarding
+1. Duplicate an existing namespace and reconfigure containers. Use new GAM, Omeda, Brightcove credentials
+2. Add tenant to `lead-management.tenants` on Aquaria
+3. Add permissions to LM user `db.grantRolesToUser('lead-management', [{ role: 'readWrite', db: 'lead-management-TENANTKEY' }])`
+4. Generate DB/Indexes: Set tenant key and boot dev instance to auto-index

--- a/manage/app/templates/campaign/edit/email.hbs
+++ b/manage/app/templates/campaign/edit/email.hbs
@@ -71,7 +71,7 @@
             <div class="form-group">
               <div class="custom-control custom-checkbox">
                 {{input type="checkbox" checked=model.enforceMaxEmailDomains class="custom-control-input" id="enforce-max-email-domains" change=(action "updateEnforceMaxEmailDomains")}}
-                <label class="custom-control-label" for="enforce-max-email-domains">Enforce maximum of three unique clicks per email domain?</label>
+                <label class="custom-control-label" for="enforce-max-email-domains">Enforce maximum of two leads per email domain?</label>
               </div>
             </div>
 

--- a/manage/app/templates/components/email-campaign/metrics-list-item.hbs
+++ b/manage/app/templates/components/email-campaign/metrics-list-item.hbs
@@ -15,7 +15,7 @@
     <small>Hide The Selected Fields: <strong>{{excludeFields}}</strong></small>
     <small>Restrict to Email Sent Dates? <strong>{{restrictToSentDate}}</strong></small>
     <small>Include delivered metrics? <strong>{{displayDeliveredMetrics}}</strong></small>
-    <small>Enforce maximum of three unique clicks per email domain? <strong>{{enforceMaxEmailDomains}}</strong></small>
+    <small>Enforce maximum of two leads per email domain? <strong>{{enforceMaxEmailDomains}}</strong></small>
     <small>ID: {{item.id}}</small>
   </div>
 </div>

--- a/manage/app/templates/order/edit/line-items/email/edit/deployments.hbs
+++ b/manage/app/templates/order/edit/line-items/email/edit/deployments.hbs
@@ -71,7 +71,7 @@
       <div class="form-group">
         <div class="custom-control custom-checkbox">
           {{input type="checkbox" checked=model.enforceMaxEmailDomains class="custom-control-input" id="enforce-max-email-domains" change=(action "updateEnforceMaxEmailDomains")}}
-          <label class="custom-control-label" for="enforce-max-email-domains">Enforce maximum of three unique clicks per email domain?</label>
+          <label class="custom-control-label" for="enforce-max-email-domains">Enforce maximum of two leads per email domain?</label>
         </div>
       </div>
     </div>

--- a/monorepo/services/server/src/services/email-report.js
+++ b/monorepo/services/server/src/services/email-report.js
@@ -190,7 +190,7 @@ module.exports = {
                 $cond: {
                   if: { $in: ['$_id.emailDomain', publicDomains] },
                   then: '$identities',
-                  else: [{ $arrayElemAt: ['$identities', 0] }],
+                  else: { $slice: ['$identities', 3] },
                 },
               },
             },

--- a/monorepo/services/server/src/services/email-report.js
+++ b/monorepo/services/server/src/services/email-report.js
@@ -172,7 +172,7 @@ module.exports = {
       // with the matching domain
       {
         $group: {
-          _id: { emailDomain: '$emailDomain', dep: '$unqClicks.dep', url: '$unqClicks.url' },
+          _id: { emailDomain: '$emailDomain' },
           identities: { $addToSet: '$_id' },
         },
       },

--- a/monorepo/services/server/src/services/email-report.js
+++ b/monorepo/services/server/src/services/email-report.js
@@ -184,13 +184,13 @@ module.exports = {
         $project: {
           idt: {
             $cond: {
-              if: { $lte: ['$identityCount', 3] },
+              if: { $lte: ['$identityCount', 2] },
               then: '$identities',
               else: {
                 $cond: {
                   if: { $in: ['$_id.emailDomain', publicDomains] },
                   then: '$identities',
-                  else: { $slice: ['$identities', 3] },
+                  else: { $slice: ['$identities', 2] },
                 },
               },
             },


### PR DESCRIPTION
- Adjust email reporting logic to ensure that the unique per-domain limit applies across multiple links and deployments.
- Adjust limit from 3 to 2, and update language in the UI.