### PR TITLE
Allow for toggling of `Advertiser CTOR` and `Total Ad Clicks per Day` columns on Leads tables

### DIFF
--- a/manage/app/components/lead-report/tables/column-toggle.js
+++ b/manage/app/components/lead-report/tables/column-toggle.js
@@ -1,0 +1,24 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: 'a',
+
+  classNames: ['clickable', 'btn', 'btn-info'],
+  attributeBindings: ['href'],
+
+  href: '#',
+
+  key: '',
+  toggleState: null,
+  label: '',
+
+  init() {
+    this._super(...arguments);
+    this.set('initialToggleState', this.get('toggleState'));
+  },
+
+  click(event) {
+    event.preventDefault();
+    this.toggleProperty('toggleState');
+  },
+});

--- a/manage/app/controllers/email/campaign-metrics.js
+++ b/manage/app/controllers/email/campaign-metrics.js
@@ -62,6 +62,8 @@ export default ListController.extend({
     ]);
     this.set('sortBy', 'fullName');
     this.set('ascending', true);
+    this.set('showAdvertiserCTOR', null);
+    this.set('showTotalAdClicksPerDay', null);
 
     this.set('limitOptions', [10, 20]);
     this.set('first', 10);

--- a/manage/app/controllers/lead-report/email/metrics.js
+++ b/manage/app/controllers/lead-report/email/metrics.js
@@ -6,5 +6,7 @@ export default ListController.extend({
     this.set('sortOptions', []);
     this.set('sortBy', 'omeda.SentDate');
     this.set('ascending', true);
+    this.set('showAdvertiserCTOR', null);
+    this.set('showTotalAdClicksPerDay', null);
   },
 });

--- a/manage/app/gql/queries/application-config.graphql
+++ b/manage/app/gql/queries/application-config.graphql
@@ -2,5 +2,6 @@ query LeadManagementAppConfig {
   currentAppConfig {
     zone
     modules { key enabled }
+    settings { key value }
   }
 }

--- a/manage/app/routes/email/campaign-metrics.js
+++ b/manage/app/routes/email/campaign-metrics.js
@@ -11,6 +11,7 @@ export default Route.extend(ListRouteMixin, {
     this.set('queryParams.rangeStart', { refreshModel: true });
     this.set('queryParams.rangeEnd', { refreshModel: true });
     this.set('queryParams.mustHaveEmailDeployments', { refreshModel: true });
+    this.set('queryParams.displayAdditionalColumns', { refreshModel: true });
   },
 
   beforeModel(transition) {

--- a/manage/app/routes/lead-report/email/metrics.js
+++ b/manage/app/routes/lead-report/email/metrics.js
@@ -11,6 +11,9 @@ export default Route.extend(RouteQueryManager, {
     ascending: {
       refreshModel: true
     },
+    displayAdditionalColumns: {
+      refreshModel: true
+    }
   },
 
   /**

--- a/manage/app/routes/lead-report/email/metrics.js
+++ b/manage/app/routes/lead-report/email/metrics.js
@@ -1,9 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject } from '@ember/service';
 import { RouteQueryManager } from 'ember-apollo-client';
 
 import query from 'leads-manage/gql/queries/lead-report/email-metrics';
 
 export default Route.extend(RouteQueryManager, {
+  config: inject(),
   queryParams: {
     sortBy: {
       refreshModel: true
@@ -11,8 +13,11 @@ export default Route.extend(RouteQueryManager, {
     ascending: {
       refreshModel: true
     },
-    displayAdditionalColumns: {
+    showAdvertiserCTOR: {
       refreshModel: true
+    },
+    showTotalAdClicksPerDay: {
+      refreshModel: true,
     }
   },
 
@@ -20,11 +25,13 @@ export default Route.extend(RouteQueryManager, {
    *
    * @param {object} params
    */
-  model({ sortBy, ascending }) {
+  model({ sortBy, ascending, showAdvertiserCTOR, showTotalAdClicksPerDay }) {
     const hash = this.modelFor('lead-report').get('hash');
 
     const sort = { field: sortBy, order: ascending ? 1 : -1 };
     const variables = { hash, sort };
+    this.set('showAdvertiserCTOR', showAdvertiserCTOR);
+    this.set('showTotalAdClicksPerDay', showTotalAdClicksPerDay);
 
     return this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, 'reportEmailMetrics');
   },
@@ -32,5 +39,23 @@ export default Route.extend(RouteQueryManager, {
   setupController(controller, model) {
     controller.set('campaign', this.modelFor('lead-report'));
     this._super(controller, model);
+    const defaultAdvertiserCTORState = typeof this.config.isSettingSet("advertiserCTORInitialVisibility") === 'boolean' ? this.config.isSettingSet("advertiserCTORInitialVisibility") : true;
+    const queryParamShowAdvertiserCTOR = this.get('showAdvertiserCTOR');
+    if (typeof queryParamShowAdvertiserCTOR === 'string' && queryParamShowAdvertiserCTOR === 'true') {
+      controller.set('showAdvertiserCTOR', true);
+    } else if (typeof queryParamShowAdvertiserCTOR === 'string' && queryParamShowAdvertiserCTOR === 'false') {
+      controller.set('showAdvertiserCTOR', false);
+    } else {
+      controller.set('showAdvertiserCTOR', defaultAdvertiserCTORState);
+    }
+    const defaultShowTotalAdClicksPerDayState = typeof this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") === 'boolean' ? this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") : true;
+    const queryParamShowTotalAdClicksPerDay = this.get('showTotalAdClicksPerDay');
+    if (typeof queryParamShowTotalAdClicksPerDay === 'string' && queryParamShowTotalAdClicksPerDay === 'true') {
+      controller.set('showTotalAdClicksPerDay', true);
+    } else if (typeof queryParamShowTotalAdClicksPerDay === 'string' && queryParamShowTotalAdClicksPerDay === 'false') {
+      controller.set('showTotalAdClicksPerDay', false);
+    } else {
+      controller.set('showTotalAdClicksPerDay', defaultShowTotalAdClicksPerDayState);
+    }
   },
 });

--- a/manage/app/routes/reports/line-items/email/metrics.js
+++ b/manage/app/routes/reports/line-items/email/metrics.js
@@ -11,6 +11,9 @@ export default Route.extend(RouteQueryManager, {
     ascending: {
       refreshModel: true
     },
+    displayAdditionalColumns: {
+      refreshModel: true
+    }
   },
 
   /**

--- a/manage/app/routes/reports/line-items/email/metrics.js
+++ b/manage/app/routes/reports/line-items/email/metrics.js
@@ -1,9 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject } from '@ember/service';
 import { RouteQueryManager } from 'ember-apollo-client';
 
 import query from 'leads-manage/gql/queries/reports/line-items/email/metrics';
 
 export default Route.extend(RouteQueryManager, {
+  config: inject(),
   queryParams: {
     sortBy: {
       refreshModel: true
@@ -11,8 +13,11 @@ export default Route.extend(RouteQueryManager, {
     ascending: {
       refreshModel: true
     },
-    displayAdditionalColumns: {
+    showAdvertiserCTOR: {
       refreshModel: true
+    },
+    showTotalAdClicksPerDay: {
+      refreshModel: true,
     }
   },
 
@@ -20,15 +25,35 @@ export default Route.extend(RouteQueryManager, {
    *
    * @param {object} params
    */
-  model({ sortBy, ascending }) {
+  model({ sortBy, ascending, showAdvertiserCTOR, showTotalAdClicksPerDay }) {
     const hash = this.modelFor('reports.line-items').get('hash');
     const sort = { field: sortBy, order: ascending ? 1 : -1 };
     const variables = { hash, sort };
+    this.set('showAdvertiserCTOR', showAdvertiserCTOR);
+    this.set('showTotalAdClicksPerDay', showTotalAdClicksPerDay);
     return this.get('apollo').watchQuery({ query, variables, fetchPolicy: 'network-only' }, 'emailLineItemMetricsReport');
   },
 
   setupController(controller, model) {
     this._super(controller, model);
     controller.set('lineItemHash', this.modelFor('reports.line-items').get('hash'));
+    const defaultAdvertiserCTORState = typeof this.config.isSettingSet("advertiserCTORInitialVisibility") === 'boolean' ? this.config.isSettingSet("advertiserCTORInitialVisibility") : true;
+    const queryParamShowAdvertiserCTOR = this.get('showAdvertiserCTOR');
+    if (typeof queryParamShowAdvertiserCTOR === 'string' && queryParamShowAdvertiserCTOR === 'true') {
+      controller.set('showAdvertiserCTOR', true);
+    } else if (typeof queryParamShowAdvertiserCTOR === 'string' && queryParamShowAdvertiserCTOR === 'false') {
+      controller.set('showAdvertiserCTOR', false);
+    } else {
+      controller.set('showAdvertiserCTOR', defaultAdvertiserCTORState);
+    }
+    const defaultShowTotalAdClicksPerDayState = typeof this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") === 'boolean' ? this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") : true;
+    const queryParamShowTotalAdClicksPerDay = this.get('showTotalAdClicksPerDay');
+    if (typeof queryParamShowTotalAdClicksPerDay === 'string' && queryParamShowTotalAdClicksPerDay === 'true') {
+      controller.set('showTotalAdClicksPerDay', true);
+    } else if (typeof queryParamShowTotalAdClicksPerDay === 'string' && queryParamShowTotalAdClicksPerDay === 'false') {
+      controller.set('showTotalAdClicksPerDay', false);
+    } else {
+      controller.set('showTotalAdClicksPerDay', defaultShowTotalAdClicksPerDayState);
+    }
   },
 });

--- a/manage/app/services/config.js
+++ b/manage/app/services/config.js
@@ -6,6 +6,7 @@ export default Service.extend({
 
   init() {
     this.modules = [];
+    this.settings = [];
     this._super(...arguments)
   },
 
@@ -18,4 +19,9 @@ export default Service.extend({
     if (found) return found.enabled;
     return false;
   },
+  isSettingSet(key) {
+    const found = this.settings.find((s) => s.key === key);
+    if (found) return found.value;
+    return null;
+  }
 });

--- a/manage/app/templates/components/email-campaign/metrics-list-item.hbs
+++ b/manage/app/templates/components/email-campaign/metrics-list-item.hbs
@@ -41,15 +41,13 @@
         sortBy=sortBy
         ascending=ascending
         class="mb-0"
-        displayAdditionalColumns=displayAdditionalColumns
+        showAdvertiserCTOR=showAdvertiserCTOR
+        showTotalAdClicksPerDay=showTotalAdClicksPerDay
       }}
     </div>
     <div class="mt-3 d-flex flex-column flex-lg-row align-items-lg-center justify-content-end">
-      {{#if displayAdditionalColumns}}
-        <p class="mr-2 mb-2"><a class="btn btn-info" role="button" href="/app/email/campaign-metrics">{{entypo-icon "circle-with-cross"}} Hide Additional Columns</a></p>
-      {{else}}
-        <p class="mr-2 mb-2"><a class="btn btn-info" role="button" href="/app/email/campaign-metrics?displayAdditionalColumns=true">{{entypo-icon "check"}} Display Additional Columns</a></p>
-      {{/if}}
+      <p class="mr-2 mb-2">{{lead-report/tables/column-toggle key="showAdvertiserCTOR" label="Advertiser CTOR" toggleState=showAdvertiserCTOR}}</p>
+      <p class="mr-2 mb-2">{{lead-report/tables/column-toggle key="showTotalAdClicksPerDay" label="Total Ad Clicks per Day" toggleState=showTotalAdClicksPerDay}}</p>
       <p class="mr-2 mb-2">{{#link-to "lead-report" item.hash class="btn btn-info"}}{{entypo-icon "pie-chart"}} View Report{{/link-to}}</p>
       <p class="mr-2 mb-2"><a class="btn btn-success" role="button" href="/export/campaign/{{item.hash}}/leads">{{entypo-icon "download"}} Download Email Leads</a></p>
       <p class="mb-2"><a class="btn btn-success" role="button" href="/export/campaign/{{item.hash}}/email/metrics">{{entypo-icon "download"}} Export Email Metrics</a></p>

--- a/manage/app/templates/components/email-campaign/metrics-list-item.hbs
+++ b/manage/app/templates/components/email-campaign/metrics-list-item.hbs
@@ -41,9 +41,15 @@
         sortBy=sortBy
         ascending=ascending
         class="mb-0"
+        displayAdditionalColumns=displayAdditionalColumns
       }}
     </div>
     <div class="mt-3 d-flex flex-column flex-lg-row align-items-lg-center justify-content-end">
+      {{#if displayAdditionalColumns}}
+        <p class="mr-2 mb-2"><a class="btn btn-info" role="button" href="/app/email/campaign-metrics">{{entypo-icon "circle-with-cross"}} Hide Additional Columns</a></p>
+      {{else}}
+        <p class="mr-2 mb-2"><a class="btn btn-info" role="button" href="/app/email/campaign-metrics?displayAdditionalColumns=true">{{entypo-icon "check"}} Display Additional Columns</a></p>
+      {{/if}}
       <p class="mr-2 mb-2">{{#link-to "lead-report" item.hash class="btn btn-info"}}{{entypo-icon "pie-chart"}} View Report{{/link-to}}</p>
       <p class="mr-2 mb-2"><a class="btn btn-success" role="button" href="/export/campaign/{{item.hash}}/leads">{{entypo-icon "download"}} Download Email Leads</a></p>
       <p class="mb-2"><a class="btn btn-success" role="button" href="/export/campaign/{{item.hash}}/email/metrics">{{entypo-icon "download"}} Export Email Metrics</a></p>

--- a/manage/app/templates/components/lead-report/tables/column-toggle.hbs
+++ b/manage/app/templates/components/lead-report/tables/column-toggle.hbs
@@ -1,0 +1,5 @@
+{{#if toggleState}}
+  {{entypo-icon "circle-with-cross"}} Hide {{label}}
+{{else}}
+  {{entypo-icon "check"}} Show {{label}}
+{{/if}}

--- a/manage/app/templates/components/lead-report/tables/email-metrics.hbs
+++ b/manage/app/templates/components/lead-report/tables/email-metrics.hbs
@@ -12,8 +12,10 @@
     <th>Open Rate</th>
     <th>CTOR</th>
     <th>CTR</th>
-    {{#if displayAdditionalColumns}}
+    {{#if showAdvertiserCTOR}}
       <th>Advertiser CTOR</th>
+    {{/if}}
+    {{#if showTotalAdClicksPerDay}}
       <th>Total Ad Clicks per Day</th>
     {{/if}}
     {{#if displayTotalUniqueClicks}}
@@ -42,8 +44,10 @@
       <td>{{ format-number row.deployment.metrics.openRate format="00.0%" }}</td>
       <td>{{ format-number row.deployment.metrics.clickToOpenRate format="00.0%" }}</td>
       <td>{{ format-number row.deployment.metrics.clickToDeliveredRate format="00.0%" }}</td>
-      {{#if displayAdditionalColumns}}
+      {{#if showAdvertiserCTOR}}
         <td>{{ format-number row.advertiserClickRate format="0.00%" }}</td>
+      {{/if}}
+      {{#if showTotalAdClicksPerDay}}
         <td>{{ format-number row.clicks format="0,0" }}</td>
       {{/if}}
       {{#if displayTotalUniqueClicks}}
@@ -66,8 +70,10 @@
     <th>{{ format-number totals.metrics.openRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToOpenRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToDeliveredRate format="00.0%" }}</th>
-    {{#if displayAdditionalColumns}}
+    {{#if showAdvertiserCTOR}}
       <th>{{ format-number totals.advertiserClickRate format="0.00%" }}</th>
+    {{/if}}
+    {{#if showTotalAdClicksPerDay}}
       <th>{{ format-number totals.clicks format="0,0" }}</th>
     {{/if}}
     {{#if displayTotalUniqueClicks}}

--- a/manage/app/templates/components/lead-report/tables/email-metrics.hbs
+++ b/manage/app/templates/components/lead-report/tables/email-metrics.hbs
@@ -12,8 +12,10 @@
     <th>Open Rate</th>
     <th>CTOR</th>
     <th>CTR</th>
-    <th>Advertiser CTOR</th>
-    <th>Total Ad Clicks per Day</th>
+    {{#if displayAdditionalColumns}}
+      <th>Advertiser CTOR</th>
+      <th>Total Ad Clicks per Day</th>
+    {{/if}}
     {{#if displayTotalUniqueClicks}}
       <th>Total Unique Clicks</th>
     {{/if}}
@@ -40,8 +42,10 @@
       <td>{{ format-number row.deployment.metrics.openRate format="00.0%" }}</td>
       <td>{{ format-number row.deployment.metrics.clickToOpenRate format="00.0%" }}</td>
       <td>{{ format-number row.deployment.metrics.clickToDeliveredRate format="00.0%" }}</td>
-      <td>{{ format-number row.advertiserClickRate format="0.00%" }}</td>
-      <td>{{ format-number row.clicks format="0,0" }}</td>
+      {{#if displayAdditionalColumns}}
+        <td>{{ format-number row.advertiserClickRate format="0.00%" }}</td>
+        <td>{{ format-number row.clicks format="0,0" }}</td>
+      {{/if}}
       {{#if displayTotalUniqueClicks}}
         <td>{{ format-number row.identities format="0,0" }}</td>
       {{/if}}
@@ -62,8 +66,10 @@
     <th>{{ format-number totals.metrics.openRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToOpenRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToDeliveredRate format="00.0%" }}</th>
-    <th>{{ format-number totals.advertiserClickRate format="0.00%" }}</th>
-    <th>{{ format-number totals.clicks format="0,0" }}</th>
+    {{#if displayAdditionalColumns}}
+      <th>{{ format-number totals.advertiserClickRate format="0.00%" }}</th>
+      <th>{{ format-number totals.clicks format="0,0" }}</th>
+    {{/if}}
     {{#if displayTotalUniqueClicks}}
       <th>{{ format-number totals.identities format="0,0" }}</th>
     {{/if}}

--- a/manage/app/templates/email/campaign-metrics.hbs
+++ b/manage/app/templates/email/campaign-metrics.hbs
@@ -91,7 +91,7 @@
         <ul class="list-group list-group-flush">
           <li class="list-group-item pt-0"><h5 class="mb-0 text-muted">Total Results: {{model.totalCount}}</h5></li>
           {{#each fetch.nodes as |item|}}
-            {{email-campaign/metrics-list-item item=item starting=rangeStart ending=rangeEnd}}
+            {{email-campaign/metrics-list-item item=item starting=rangeStart ending=rangeEnd displayAdditionalColumns=displayAdditionalColumns}}
           {{/each}}
         </ul>
 

--- a/manage/app/templates/email/campaign-metrics.hbs
+++ b/manage/app/templates/email/campaign-metrics.hbs
@@ -91,7 +91,13 @@
         <ul class="list-group list-group-flush">
           <li class="list-group-item pt-0"><h5 class="mb-0 text-muted">Total Results: {{model.totalCount}}</h5></li>
           {{#each fetch.nodes as |item|}}
-            {{email-campaign/metrics-list-item item=item starting=rangeStart ending=rangeEnd displayAdditionalColumns=displayAdditionalColumns}}
+            {{email-campaign/metrics-list-item
+              item=item
+              starting=rangeStart
+              ending=rangeEnd
+              showAdvertiserCTOR=showAdvertiserCTOR
+              showTotalAdClicksPerDay=showTotalAdClicksPerDay
+            }}
           {{/each}}
         </ul>
 

--- a/manage/app/templates/lead-report/email/metrics.hbs
+++ b/manage/app/templates/lead-report/email/metrics.hbs
@@ -32,7 +32,8 @@
             sortBy=sortBy
             ascending=ascending
             class="mb-0"
-            displayAdditionalColumns=displayAdditionalColumns
+            showAdvertiserCTOR=showAdvertiserCTOR
+            showTotalAdClicksPerDay=showTotalAdClicksPerDay
           }}
         </div>
       </div>
@@ -42,10 +43,7 @@
   {{/if}}
 </div>
 <div class="card-footer text-right">
-  {{#if displayAdditionalColumns}}
-    <a class="btn btn-info" role="button" href="/app/lead-report/{{campaign.hash}}">{{entypo-icon "circle-with-cross"}} Hide Additional Columns</a>
-  {{else}}
-     <a class="btn btn-info" role="button" href="/app/lead-report/{{campaign.hash}}?displayAdditionalColumns=true">{{entypo-icon "check"}} Display Additional Columns</a>
-  {{/if}}
+  {{lead-report/tables/column-toggle key="showAdvertiserCTOR" label="Advertiser CTOR" toggleState=showAdvertiserCTOR}}
+  {{lead-report/tables/column-toggle key="showTotalAdClicksPerDay" label="Total Ad Clicks per Day" toggleState=showTotalAdClicksPerDay}}
   <a class="btn btn-success" role="button" href="/export/campaign/{{campaign.hash}}/email/metrics">{{entypo-icon "download"}} Export Email Metrics</a>
 </div>

--- a/manage/app/templates/lead-report/email/metrics.hbs
+++ b/manage/app/templates/lead-report/email/metrics.hbs
@@ -32,6 +32,7 @@
             sortBy=sortBy
             ascending=ascending
             class="mb-0"
+            displayAdditionalColumns=displayAdditionalColumns
           }}
         </div>
       </div>
@@ -41,5 +42,10 @@
   {{/if}}
 </div>
 <div class="card-footer text-right">
+  {{#if displayAdditionalColumns}}
+    <a class="btn btn-info" role="button" href="/app/lead-report/{{campaign.hash}}">{{entypo-icon "circle-with-cross"}} Hide Additional Columns</a>
+  {{else}}
+     <a class="btn btn-info" role="button" href="/app/lead-report/{{campaign.hash}}?displayAdditionalColumns=true">{{entypo-icon "check"}} Display Additional Columns</a>
+  {{/if}}
   <a class="btn btn-success" role="button" href="/export/campaign/{{campaign.hash}}/email/metrics">{{entypo-icon "download"}} Export Email Metrics</a>
 </div>

--- a/manage/app/templates/reports/line-items/email/metrics.hbs
+++ b/manage/app/templates/reports/line-items/email/metrics.hbs
@@ -31,7 +31,8 @@
             sortBy=sortBy
             ascending=ascending
             class="mb-0"
-            displayAdditionalColumns=displayAdditionalColumns
+            showAdvertiserCTOR=showAdvertiserCTOR
+            showTotalAdClicksPerDay=showTotalAdClicksPerDay
           }}
         </div>
       </div>
@@ -41,10 +42,7 @@
   {{/if}}
 </div>
 <div class="card-footer text-right">
-  {{#if displayAdditionalColumns}}
-    <a class="btn btn-info" role="button" href="/app/reports/line-items/{{lineItemHash}}/email">{{entypo-icon "circle-with-cross"}} Hide Additional Columns</a>
-  {{else}}
-     <a class="btn btn-info" role="button" href="/app/reports/line-items/{{lineItemHash}}/email?displayAdditionalColumns=true">{{entypo-icon "check"}} Display Additional Columns</a>
-  {{/if}}
+  {{lead-report/tables/column-toggle key="showAdvertiserCTOR" label="Advertiser CTOR" toggleState=showAdvertiserCTOR}}
+  {{lead-report/tables/column-toggle key="showTotalAdClicksPerDay" label="Total Ad Clicks per Day" toggleState=showTotalAdClicksPerDay}}
   <a class="btn btn-success" role="button" href="/export/line-item/{{lineItemHash}}/email/metrics">{{entypo-icon "download"}} Export Email Metrics</a>
 </div>

--- a/manage/app/templates/reports/line-items/email/metrics.hbs
+++ b/manage/app/templates/reports/line-items/email/metrics.hbs
@@ -31,6 +31,7 @@
             sortBy=sortBy
             ascending=ascending
             class="mb-0"
+            displayAdditionalColumns=displayAdditionalColumns
           }}
         </div>
       </div>
@@ -40,5 +41,10 @@
   {{/if}}
 </div>
 <div class="card-footer text-right">
+  {{#if displayAdditionalColumns}}
+    <a class="btn btn-info" role="button" href="/app/reports/line-items/{{lineItemHash}}/email">{{entypo-icon "circle-with-cross"}} Hide Additional Columns</a>
+  {{else}}
+     <a class="btn btn-info" role="button" href="/app/reports/line-items/{{lineItemHash}}/email?displayAdditionalColumns=true">{{entypo-icon "check"}} Display Additional Columns</a>
+  {{/if}}
   <a class="btn btn-success" role="button" href="/export/line-item/{{lineItemHash}}/email/metrics">{{entypo-icon "download"}} Export Email Metrics</a>
 </div>

--- a/monorepo/services/server/src/graphql/definitions/config.js
+++ b/monorepo/services/server/src/graphql/definitions/config.js
@@ -10,11 +10,17 @@ type AppConfig {
   _id: ObjectID!
   zone: String!
   modules: [AppModuleConfig!]!
+  settings: [AppSettingConfig!]!
 }
 
 type AppModuleConfig {
   key: String!
   enabled: Boolean!
+}
+
+type AppSettingConfig {
+  key: String!
+  value: Boolean!
 }
 
 `;

--- a/monorepo/services/server/src/graphql/resolvers/config.js
+++ b/monorepo/services/server/src/graphql/resolvers/config.js
@@ -11,6 +11,7 @@ module.exports = {
     currentAppConfig: async (root, _, { tenant }) => {
       const { doc } = tenant;
       const modules = doc.modules || {};
+      const settings = doc.settings || {};
       return {
         _id: doc._id,
         zone: doc.zone,
@@ -18,6 +19,10 @@ module.exports = {
           key,
           enabled: get(modules, `${key}.enabled`, false),
           // Other configs, eventually?
+        })),
+        settings: Object.keys(settings).map((key) => ({
+          key,
+          value: get(modules, `${key}.value`),
         })),
       };
     },


### PR DESCRIPTION
![Screenshot from 2023-08-02 11-41-08](https://github.com/parameter1/lead-management/assets/46794001/59d27a1c-2a81-4dfd-8c0e-09edd36df8e3)
![Screenshot from 2023-08-02 11-41-18](https://github.com/parameter1/lead-management/assets/46794001/d0b632a3-a9f0-41ed-b594-5a6514ab9335)
![Screenshot from 2023-08-02 11-41-24](https://github.com/parameter1/lead-management/assets/46794001/d50d0675-2dd1-473d-825a-eee02d590834)
![Screenshot from 2023-08-02 11-41-50](https://github.com/parameter1/lead-management/assets/46794001/6082509c-5186-46e1-ab42-47a6092f8b19)
![Screenshot from 2023-08-02 11-41-55](https://github.com/parameter1/lead-management/assets/46794001/95de035b-913b-413b-bee8-2b5d05ee76ae)
![Screenshot from 2023-08-02 11-41-59](https://github.com/parameter1/lead-management/assets/46794001/95b9d96f-39a3-450e-8dca-07a43b15a1b0)
![Screenshot from 2023-08-02 11-42-19](https://github.com/parameter1/lead-management/assets/46794001/e7b0f82b-e055-4389-8abc-9b2cc9f2d849)
![Screenshot from 2023-08-02 11-42-26](https://github.com/parameter1/lead-management/assets/46794001/0f4d7890-f8df-41fd-ba0f-2ed52ade0726)
![Screenshot from 2023-08-02 11-42-36](https://github.com/parameter1/lead-management/assets/46794001/5e11903f-c812-4436-8e2d-9b152cf20111)
