### PR TITLE
Allow for toggling of `Advertiser CTOR` and `Total Ad Clicks per Day` columns per campaign

### DIFF
--- a/manage/app/gql/fragments/campaign/view.graphql
+++ b/manage/app/gql/fragments/campaign/view.graphql
@@ -5,6 +5,8 @@ fragment CampaignViewFragment on Campaign {
   name
   hash
   maxIdentities
+  showAdvertiserCTOR
+  showTotalAdClicksPerDay
   range {
     start
     end

--- a/manage/app/gql/queries/application-config.graphql
+++ b/manage/app/gql/queries/application-config.graphql
@@ -2,5 +2,6 @@ query LeadManagementAppConfig {
   currentAppConfig {
     zone
     modules { key enabled }
+    settings { key value }
   }
 }

--- a/manage/app/gql/queries/email/campaign-metrics.graphql
+++ b/manage/app/gql/queries/email/campaign-metrics.graphql
@@ -7,6 +7,8 @@ query EmailCampaignMetrics($input: AllCampaignsQueryInput = {}, $pagination: Pag
         fullName
         hash
         maxIdentities
+        showAdvertiserCTOR
+        showTotalAdClicksPerDay
         salesRep {
           id
           givenName

--- a/manage/app/gql/queries/lead-report/email-metrics.graphql
+++ b/manage/app/gql/queries/lead-report/email-metrics.graphql
@@ -2,8 +2,11 @@
 
 query LeadReportEmailMetrics($hash: String!, $sort: ReportEmailMetricsSortInput!, $starting: Date, $ending: Date) {
   reportEmailMetrics(hash: $hash, sort: $sort, starting: $starting, ending: $ending) {
-    showAdvertiserCTOR
-    showTotalAdClicksPerDay
+    campaign {
+      id
+      showAdvertiserCTOR
+      showTotalAdClicksPerDay
+    }
     deployments {
       deployment {
         id

--- a/manage/app/gql/queries/lead-report/email-metrics.graphql
+++ b/manage/app/gql/queries/lead-report/email-metrics.graphql
@@ -2,6 +2,8 @@
 
 query LeadReportEmailMetrics($hash: String!, $sort: ReportEmailMetricsSortInput!, $starting: Date, $ending: Date) {
   reportEmailMetrics(hash: $hash, sort: $sort, starting: $starting, ending: $ending) {
+    showAdvertiserCTOR
+    showTotalAdClicksPerDay
     deployments {
       deployment {
         id

--- a/manage/app/routes/campaign/create.js
+++ b/manage/app/routes/campaign/create.js
@@ -15,13 +15,21 @@ export default Route.extend(RouteQueryManager, FormMixin, {
         start: null,
         end: null,
       },
-      showAdvertiserCTOR: typeof this.config.isSettingSet("advertiserCTORInitialVisibility") === 'boolean' ? this.config.isSettingSet("advertiserCTORInitialVisibility") : true,
-      showTotalAdClicksPerDay: typeof this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") === 'boolean' ? this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") : true,
+      showAdvertiserCTOR: this.config.getSetting('advertiserCTORInitialVisibility', true),
+      showTotalAdClicksPerDay: this.config.getSetting('totalAdClicksPerDayInitialVisibility', true),
     };
   },
 
   actions: {
-    async create({ customer, salesRep, name, range, maxIdentities, showAdvertiserCTOR, showTotalAdClicksPerDay }) {
+    async create({
+      customer,
+      salesRep,
+      name,
+      range,
+      maxIdentities,
+      showAdvertiserCTOR,
+      showTotalAdClicksPerDay,
+    }) {
       try {
         this.startRouteAction();
         const customerId = get(customer || {}, 'id');

--- a/manage/app/routes/campaign/create.js
+++ b/manage/app/routes/campaign/create.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import { inject } from '@ember/service';
 import { RouteQueryManager } from 'ember-apollo-client';
 import FormMixin from 'leads-manage/mixins/form-mixin';
 import { get } from '@ember/object';
@@ -6,6 +7,7 @@ import { get } from '@ember/object';
 import mutation from 'leads-manage/gql/mutations/campaign/create';
 
 export default Route.extend(RouteQueryManager, FormMixin, {
+  config: inject(),
   model() {
     return {
       maxIdentities: 200,
@@ -13,11 +15,13 @@ export default Route.extend(RouteQueryManager, FormMixin, {
         start: null,
         end: null,
       },
+      showAdvertiserCTOR: typeof this.config.isSettingSet("advertiserCTORInitialVisibility") === 'boolean' ? this.config.isSettingSet("advertiserCTORInitialVisibility") : true,
+      showTotalAdClicksPerDay: typeof this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") === 'boolean' ? this.config.isSettingSet("totalAdClicksPerDayInitialVisibility") : true,
     };
   },
 
   actions: {
-    async create({ customer, salesRep, name, range, maxIdentities }) {
+    async create({ customer, salesRep, name, range, maxIdentities, showAdvertiserCTOR, showTotalAdClicksPerDay }) {
       try {
         this.startRouteAction();
         const customerId = get(customer || {}, 'id');
@@ -33,6 +37,8 @@ export default Route.extend(RouteQueryManager, FormMixin, {
           startDate: range.start.valueOf(),
           endDate: range.end.valueOf(),
           maxIdentities: parseInt(maxIdentities, 10),
+          showAdvertiserCTOR,
+          showTotalAdClicksPerDay
         };
         const variables = { input };
         const response = await this.get('apollo').mutate({ mutation, variables }, 'createCampaign');

--- a/manage/app/routes/campaign/edit/index.js
+++ b/manage/app/routes/campaign/edit/index.js
@@ -17,7 +17,16 @@ export default Route.extend(FormMixin, RouteQueryManager, {
      *
      * @param {object} params
      */
-    async update({ id, customer, salesRep, name, range, maxIdentities, showAdvertiserCTOR, showTotalAdClicksPerDay }) {
+    async update({
+      id,
+      customer,
+      salesRep,
+      name,
+      range,
+      maxIdentities,
+      showAdvertiserCTOR,
+      showTotalAdClicksPerDay,
+    }) {
       try {
         this.startRouteAction();
         const customerId = get(customer || {}, 'id');

--- a/manage/app/routes/campaign/edit/index.js
+++ b/manage/app/routes/campaign/edit/index.js
@@ -17,7 +17,7 @@ export default Route.extend(FormMixin, RouteQueryManager, {
      *
      * @param {object} params
      */
-    async update({ id, customer, salesRep, name, range, maxIdentities }) {
+    async update({ id, customer, salesRep, name, range, maxIdentities, showAdvertiserCTOR, showTotalAdClicksPerDay }) {
       try {
         this.startRouteAction();
         const customerId = get(customer || {}, 'id');
@@ -33,6 +33,8 @@ export default Route.extend(FormMixin, RouteQueryManager, {
           startDate: range.start.valueOf(),
           endDate: range.end.valueOf(),
           maxIdentities: parseInt(maxIdentities, 10),
+          showAdvertiserCTOR,
+          showTotalAdClicksPerDay
         };
         const input = { id, payload };
         const variables = { input };

--- a/manage/app/services/config.js
+++ b/manage/app/services/config.js
@@ -6,6 +6,7 @@ export default Service.extend({
 
   init() {
     this.modules = [];
+    this.settings = [];
     this._super(...arguments)
   },
 
@@ -18,4 +19,9 @@ export default Service.extend({
     if (found) return found.enabled;
     return false;
   },
+  isSettingSet(key) {
+    const found = this.settings.find((s) => s.key === key);
+    if (found) return found.value;
+    return null;
+  }
 });

--- a/manage/app/services/config.js
+++ b/manage/app/services/config.js
@@ -19,9 +19,8 @@ export default Service.extend({
     if (found) return found.enabled;
     return false;
   },
-  isSettingSet(key) {
+  getSetting(key, defaultValue = false) {
     const found = this.settings.find((s) => s.key === key);
-    if (found) return found.value;
-    return null;
+    return found ? found.value : defaultValue;
   }
 });

--- a/manage/app/templates/campaign/form.hbs
+++ b/manage/app/templates/campaign/form.hbs
@@ -44,7 +44,7 @@
       <small id="campaign-name-help" class="form-text text-muted hide">Optional. The campaign name - should be descriptive.</small>
     </div>
 
-    <div class="form-group mb-0">
+    <div class="form-group">
       <label for="maxIdentities">Maximum Leads</label>
       {{#if user.isAdmin}}
         {{input type="number" min=0 value=model.maxIdentities class="form-control" id="maxIdentities" aria-describedby="maxIdentitiesHelp" placeholder="Max Leads"}}
@@ -53,6 +53,19 @@
         {{input type="number" min=1 max=200 value=model.maxIdentities class="form-control" id="maxIdentities" aria-describedby="maxIdentitiesHelp" placeholder="Max Leads"}}
         <small id="maxIdentitiesHelp" class="form-text text-muted">Maximum 200.</small>
       {{/if}}
+    </div>
+
+    <div class="form-group mb-0">
+      <div class="custom-control custom-checkbox">
+        {{input type="checkbox" checked=model.showAdvertiserCTOR class="custom-control-input" id="showAdvertiserCTOR" aria-describedby="showAdvertiserCTORHelp"}}
+        <label class="custom-control-label" for="showAdvertiserCTOR">Show Advertiser CTOR?</label>
+        <small id="showAdvertiserCTORHelp" class="form-text text-muted">Whether or not Advertiser CTOR should be shown on reports</small>
+      </div>
+      <div class="custom-control custom-checkbox">
+        {{input type="checkbox" checked=model.showTotalAdClicksPerDay class="custom-control-input" id="showTotalAdClicksPerDay" aria-describedby="showTotalAdClicksPerDayHelp"}}
+        <label class="custom-control-label" for="showTotalAdClicksPerDay">Show Total Ad Clicks per Day?</label>
+        <small id="showTotalAdClicksPerDayHelp" class="form-text text-muted">Whether or not Total Ad Clicks per Day should be shown on reports</small>
+      </div>
     </div>
 
   </div>

--- a/manage/app/templates/components/email-campaign/metrics-list-item.hbs
+++ b/manage/app/templates/components/email-campaign/metrics-list-item.hbs
@@ -36,6 +36,8 @@
       {{/if}}
       {{lead-report/tables/email-metrics
         displayDeliveredMetrics=item.email.displayDeliveredMetrics
+        showAdvertiserCTOR=item.showAdvertiserCTOR
+        showTotalAdClicksPerDay=item.showTotalAdClicksPerDay
         deployments=data.deployments
         totals=data.totals
         sortBy=sortBy

--- a/manage/app/templates/components/lead-report/tables/email-metrics.hbs
+++ b/manage/app/templates/components/lead-report/tables/email-metrics.hbs
@@ -12,8 +12,12 @@
     <th>Open Rate</th>
     <th>CTOR</th>
     <th>CTR</th>
-    <th>Advertiser CTOR</th>
-    <th>Total Ad Clicks per Day</th>
+    {{#if showAdvertiserCTOR}}
+      <th>Advertiser CTOR</th>
+    {{/if}}
+    {{#if showTotalAdClicksPerDay}}
+      <th>Total Ad Clicks per Day</th>
+    {{/if}}
     {{#if displayTotalUniqueClicks}}
       <th>Total Unique Clicks</th>
     {{/if}}
@@ -40,8 +44,12 @@
       <td>{{ format-number row.deployment.metrics.openRate format="00.0%" }}</td>
       <td>{{ format-number row.deployment.metrics.clickToOpenRate format="00.0%" }}</td>
       <td>{{ format-number row.deployment.metrics.clickToDeliveredRate format="00.0%" }}</td>
-      <td>{{ format-number row.advertiserClickRate format="0.00%" }}</td>
-      <td>{{ format-number row.clicks format="0,0" }}</td>
+      {{#if showAdvertiserCTOR}}
+        <td>{{ format-number row.advertiserClickRate format="0.00%" }}</td>
+      {{/if}}
+      {{#if showTotalAdClicksPerDay}}
+        <td>{{ format-number row.clicks format="0,0" }}</td>
+      {{/if}}
       {{#if displayTotalUniqueClicks}}
         <td>{{ format-number row.identities format="0,0" }}</td>
       {{/if}}
@@ -62,8 +70,12 @@
     <th>{{ format-number totals.metrics.openRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToOpenRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToDeliveredRate format="00.0%" }}</th>
-    <th>{{ format-number totals.advertiserClickRate format="0.00%" }}</th>
-    <th>{{ format-number totals.clicks format="0,0" }}</th>
+    {{#if showAdvertiserCTOR}}
+      <th>{{ format-number totals.advertiserClickRate format="0.00%" }}</th>
+    {{/if}}
+    {{#if showTotalAdClicksPerDay}}
+      <th>{{ format-number totals.clicks format="0,0" }}</th>
+    {{/if}}
     {{#if displayTotalUniqueClicks}}
       <th>{{ format-number totals.identities format="0,0" }}</th>
     {{/if}}

--- a/manage/app/templates/lead-report/email/metrics.hbs
+++ b/manage/app/templates/lead-report/email/metrics.hbs
@@ -27,8 +27,8 @@
         <div class="table-responsive">
           {{lead-report/tables/email-metrics
             displayDeliveredMetrics=campaign.email.displayDeliveredMetrics
-            showAdvertiserCTOR=model.showAdvertiserCTOR
-            showTotalAdClicksPerDay=model.showTotalAdClicksPerDay
+            showAdvertiserCTOR=model.campaign.showAdvertiserCTOR
+            showTotalAdClicksPerDay=model.campaign.showTotalAdClicksPerDay
             deployments=model.deployments
             totals=model.totals
             sortBy=sortBy

--- a/manage/app/templates/lead-report/email/metrics.hbs
+++ b/manage/app/templates/lead-report/email/metrics.hbs
@@ -27,6 +27,8 @@
         <div class="table-responsive">
           {{lead-report/tables/email-metrics
             displayDeliveredMetrics=campaign.email.displayDeliveredMetrics
+            showAdvertiserCTOR=model.showAdvertiserCTOR
+            showTotalAdClicksPerDay=model.showTotalAdClicksPerDay
             deployments=model.deployments
             totals=model.totals
             sortBy=sortBy

--- a/manage/app/templates/reports/line-items/email/metrics.hbs
+++ b/manage/app/templates/reports/line-items/email/metrics.hbs
@@ -27,6 +27,8 @@
         <div class="table-responsive">
           {{lead-report/tables/email-metrics
             deployments=model.deployments
+            showAdvertiserCTOR=true
+            showTotalAdClicksPerDay=true
             totals=model.totals
             sortBy=sortBy
             ascending=ascending

--- a/monorepo/services/exports/src/actions/campaign/email-metrics.js
+++ b/monorepo/services/exports/src/actions/campaign/email-metrics.js
@@ -23,8 +23,11 @@ const METRICS_FRAGMENT = gql`
 const QUERY = gql`
   query ExportCampaignEmailMetrics($hash: String!, $sort: ReportEmailMetricsSortInput!) {
     reportEmailMetrics(hash: $hash, sort: $sort) {
-      showAdvertiserCTOR
-      showTotalAdClicksPerDay
+      campaign {
+        id
+        showAdvertiserCTOR
+        showTotalAdClicksPerDay
+      }
       deployments {
         identities
         clicks
@@ -62,8 +65,8 @@ module.exports = async (params = {}, { context }) => {
   const { apollo } = context;
   const variables = { hash, sort: { field: 'sentDate', order: 1 } };
   const { data } = await apollo.query({ query: QUERY, variables });
-  const showAdvertiserCTOR = get(data, 'reportEmailMetrics.showAdvertiserCTOR');
-  const showTotalAdClicksPerDay = get(data, 'reportEmailMetrics.showTotalAdClicksPerDay');
+  const showAdvertiserCTOR = get(data, 'reportEmailMetrics.campaign.showAdvertiserCTOR');
+  const showTotalAdClicksPerDay = get(data, 'reportEmailMetrics.campaign.showTotalAdClicksPerDay');
 
   const rows = getAsArray(data, 'reportEmailMetrics.deployments').map((row) => {
     const { deployment } = row;

--- a/monorepo/services/server/src/graphql/definitions/campaign.js
+++ b/monorepo/services/server/src/graphql/definitions/campaign.js
@@ -68,6 +68,8 @@ type Campaign {
   deleted: Boolean!
   createdAt: Date
   updatedAt: Date
+  showAdvertiserCTOR: Boolean!
+  showTotalAdClicksPerDay: Boolean!
 
   gamLineItems(input: CampaignGAMLineItemsInput = {}): GAM_LineItemConnection!
   gamLineItemReport: JSON
@@ -260,6 +262,8 @@ input CreateCampaignInput {
   maxIdentities: Int
   startDate: Date
   endDate: Date
+  showAdvertiserCTOR: Boolean!
+  showTotalAdClicksPerDay: Boolean!
 }
 
 input UpdateCampaignPayloadInput {
@@ -269,6 +273,8 @@ input UpdateCampaignPayloadInput {
   maxIdentities: Int
   startDate: Date
   endDate: Date
+  showAdvertiserCTOR: Boolean!
+  showTotalAdClicksPerDay: Boolean!
 }
 
 input UpdateCampaignInput {

--- a/monorepo/services/server/src/graphql/definitions/config.js
+++ b/monorepo/services/server/src/graphql/definitions/config.js
@@ -10,6 +10,7 @@ type AppConfig {
   _id: ObjectID!
   zone: String!
   modules: [AppModuleConfig!]!
+  settings: [AppSettingConfig!]!
 }
 
 type AppModuleConfig {
@@ -17,4 +18,8 @@ type AppModuleConfig {
   enabled: Boolean!
 }
 
+type AppSettingConfig {
+  key: String!
+  value: Boolean!
+}
 `;

--- a/monorepo/services/server/src/graphql/definitions/lead-report.js
+++ b/monorepo/services/server/src/graphql/definitions/lead-report.js
@@ -15,8 +15,7 @@ extend type Query {
 type ReportEmailMetrics {
   deployments: [ReportEmailMetricDeployment!]!
   totals: ReportEmailMetricTotals!
-  showAdvertiserCTOR: Boolean!
-  showTotalAdClicksPerDay: Boolean!
+  campaign: Campaign!
 }
 
 type ReportEmailMetricTotals {

--- a/monorepo/services/server/src/graphql/definitions/lead-report.js
+++ b/monorepo/services/server/src/graphql/definitions/lead-report.js
@@ -15,6 +15,8 @@ extend type Query {
 type ReportEmailMetrics {
   deployments: [ReportEmailMetricDeployment!]!
   totals: ReportEmailMetricTotals!
+  showAdvertiserCTOR: Boolean!
+  showTotalAdClicksPerDay: Boolean!
 }
 
 type ReportEmailMetricTotals {

--- a/monorepo/services/server/src/graphql/resolvers/campaign.js
+++ b/monorepo/services/server/src/graphql/resolvers/campaign.js
@@ -694,6 +694,8 @@ module.exports = {
         startDate,
         endDate,
         maxIdentities,
+        showAdvertiserCTOR,
+        showTotalAdClicksPerDay,
       } = input;
 
       const record = new Campaign({
@@ -703,6 +705,8 @@ module.exports = {
         startDate,
         endDate,
         maxIdentities: calcMax(auth, maxIdentities),
+        showAdvertiserCTOR,
+        showTotalAdClicksPerDay,
       });
       return record.save();
     },
@@ -742,6 +746,8 @@ module.exports = {
         startDate,
         endDate,
         maxIdentities,
+        showAdvertiserCTOR,
+        showTotalAdClicksPerDay,
       } = payload;
 
       const record = await Campaign.findOne({ _id: id || null, deleted: false });
@@ -753,6 +759,8 @@ module.exports = {
         startDate,
         endDate,
         maxIdentities: calcMax(auth, maxIdentities),
+        showAdvertiserCTOR,
+        showTotalAdClicksPerDay,
       });
       return record.save();
     },

--- a/monorepo/services/server/src/graphql/resolvers/config.js
+++ b/monorepo/services/server/src/graphql/resolvers/config.js
@@ -11,6 +11,7 @@ module.exports = {
     currentAppConfig: async (root, _, { tenant }) => {
       const { doc } = tenant;
       const modules = doc.modules || {};
+      const settings = doc.settings || {};
       return {
         _id: doc._id,
         zone: doc.zone,
@@ -18,6 +19,10 @@ module.exports = {
           key,
           enabled: get(modules, `${key}.enabled`, false),
           // Other configs, eventually?
+        })),
+        settings: Object.keys(settings).map((key) => ({
+          key,
+          value: get(modules, `${key}.value`),
         })),
       };
     },

--- a/monorepo/services/server/src/graphql/resolvers/lead-report.js
+++ b/monorepo/services/server/src/graphql/resolvers/lead-report.js
@@ -97,7 +97,18 @@ module.exports = {
         },
       });
       const results = await OmedaEmailClick.aggregate(pipeline);
-      return emailReportService.buildEmailMetrics({ results, sort, deploymentEntities });
+      const metricsObj = await emailReportService.buildEmailMetrics({
+        results,
+        sort,
+        deploymentEntities,
+      });
+      const { showAdvertiserCTOR, showTotalAdClicksPerDay } = campaign;
+      const outputObj = {
+        ...metricsObj,
+        showAdvertiserCTOR,
+        showTotalAdClicksPerDay,
+      };
+      return outputObj;
     },
 
     /**

--- a/monorepo/services/server/src/graphql/resolvers/lead-report.js
+++ b/monorepo/services/server/src/graphql/resolvers/lead-report.js
@@ -102,12 +102,7 @@ module.exports = {
         sort,
         deploymentEntities,
       });
-      const { showAdvertiserCTOR, showTotalAdClicksPerDay } = campaign;
-      const outputObj = {
-        ...metricsObj,
-        showAdvertiserCTOR,
-        showTotalAdClicksPerDay,
-      };
+      const outputObj = { ...metricsObj, campaign };
       return outputObj;
     },
 

--- a/monorepo/services/server/src/mongodb/schema/campaign.js
+++ b/monorepo/services/server/src/mongodb/schema/campaign.js
@@ -245,6 +245,16 @@ const schema = new Schema({
     required: true,
     default: false,
   },
+  showAdvertiserCTOR: {
+    type: Boolean,
+    required: true,
+    default: true,
+  },
+  showTotalAdClicksPerDay: {
+    type: Boolean,
+    required: true,
+    default: true,
+  },
   email: {
     type: emailSchema,
     default: {},


### PR DESCRIPTION
**REPLACES:** https://github.com/parameter1/lead-management/pull/34

Both fields toggled off:
![Screenshot from 2023-08-07 13-57-15](https://github.com/parameter1/lead-management/assets/46794001/fb71c17f-2f90-4426-87b9-1661e533201a)
![Screenshot from 2023-08-07 13-57-30](https://github.com/parameter1/lead-management/assets/46794001/577857c4-67ed-403c-a569-d8b22eeb8de0)
![Screenshot from 2023-08-07 14-10-16](https://github.com/parameter1/lead-management/assets/46794001/097d865a-d7c0-4f18-b6f6-8217025498a1)

Both fields toggled on:
![Screenshot from 2023-08-07 13-58-05](https://github.com/parameter1/lead-management/assets/46794001/44cd40a6-b2d5-4957-bf3d-56cb6fa77aa9)
![Screenshot from 2023-08-07 13-58-19](https://github.com/parameter1/lead-management/assets/46794001/ca8388aa-3334-4350-8b77-bf592b25fda9)
![Screenshot from 2023-08-07 14-08-53](https://github.com/parameter1/lead-management/assets/46794001/db52486a-5db1-4e58-83fc-00887d330bfe)


Ensuring the behavior of the Line Item report isn't impacted by these changes (see: https://github.com/parameter1/lead-management/commit/40e2f6c3a032d78cb2d4b598a9fadbf6c72880ac)
![Screenshot from 2023-08-07 14-22-39](https://github.com/parameter1/lead-management/assets/46794001/0a4e86cd-84ae-4e37-a122-371a592435c0)


This will remove these respective columns from the reports and exports that include them that have context of the campaign they are apart of.