### PR TITLE
Allow for toggling of `Total Unique Clicks` column per campaign

### DIFF
--- a/manage/app/components/lead-report/tables/email-metrics.js
+++ b/manage/app/components/lead-report/tables/email-metrics.js
@@ -20,8 +20,6 @@ export default Component.extend({
     return deployments.every(({ deployment }) => deployment.designation === 'Newsletter');
   }),
 
-  displayTotalUniqueClicks: false,
-
   init() {
     this._super(...arguments);
     this.set('iframe', {

--- a/manage/app/gql/fragments/campaign/view.graphql
+++ b/manage/app/gql/fragments/campaign/view.graphql
@@ -7,6 +7,7 @@ fragment CampaignViewFragment on Campaign {
   maxIdentities
   showAdvertiserCTOR
   showTotalAdClicksPerDay
+  showTotalUniqueClicks
   range {
     start
     end

--- a/manage/app/gql/queries/email/campaign-metrics.graphql
+++ b/manage/app/gql/queries/email/campaign-metrics.graphql
@@ -9,6 +9,7 @@ query EmailCampaignMetrics($input: AllCampaignsQueryInput = {}, $pagination: Pag
         maxIdentities
         showAdvertiserCTOR
         showTotalAdClicksPerDay
+        showTotalUniqueClicks
         salesRep {
           id
           givenName

--- a/manage/app/gql/queries/lead-report/email-metrics.graphql
+++ b/manage/app/gql/queries/lead-report/email-metrics.graphql
@@ -6,6 +6,7 @@ query LeadReportEmailMetrics($hash: String!, $sort: ReportEmailMetricsSortInput!
       id
       showAdvertiserCTOR
       showTotalAdClicksPerDay
+      showTotalUniqueClicks
     }
     deployments {
       deployment {

--- a/manage/app/routes/campaign/create.js
+++ b/manage/app/routes/campaign/create.js
@@ -17,6 +17,7 @@ export default Route.extend(RouteQueryManager, FormMixin, {
       },
       showAdvertiserCTOR: this.config.getSetting('advertiserCTORInitialVisibility', true),
       showTotalAdClicksPerDay: this.config.getSetting('totalAdClicksPerDayInitialVisibility', true),
+      showTotalUniqueClicks: this.config.getSetting('totalUniqueClicksInitialVisibility', true),
     };
   },
 
@@ -29,6 +30,7 @@ export default Route.extend(RouteQueryManager, FormMixin, {
       maxIdentities,
       showAdvertiserCTOR,
       showTotalAdClicksPerDay,
+      showTotalUniqueClicks,
     }) {
       try {
         this.startRouteAction();
@@ -46,7 +48,8 @@ export default Route.extend(RouteQueryManager, FormMixin, {
           endDate: range.end.valueOf(),
           maxIdentities: parseInt(maxIdentities, 10),
           showAdvertiserCTOR,
-          showTotalAdClicksPerDay
+          showTotalAdClicksPerDay,
+          showTotalUniqueClicks
         };
         const variables = { input };
         const response = await this.get('apollo').mutate({ mutation, variables }, 'createCampaign');

--- a/manage/app/routes/campaign/edit/index.js
+++ b/manage/app/routes/campaign/edit/index.js
@@ -26,6 +26,7 @@ export default Route.extend(FormMixin, RouteQueryManager, {
       maxIdentities,
       showAdvertiserCTOR,
       showTotalAdClicksPerDay,
+      showTotalUniqueClicks,
     }) {
       try {
         this.startRouteAction();
@@ -43,7 +44,8 @@ export default Route.extend(FormMixin, RouteQueryManager, {
           endDate: range.end.valueOf(),
           maxIdentities: parseInt(maxIdentities, 10),
           showAdvertiserCTOR,
-          showTotalAdClicksPerDay
+          showTotalAdClicksPerDay,
+          showTotalUniqueClicks
         };
         const input = { id, payload };
         const variables = { input };

--- a/manage/app/templates/campaign/form.hbs
+++ b/manage/app/templates/campaign/form.hbs
@@ -66,6 +66,11 @@
         <label class="custom-control-label" for="showTotalAdClicksPerDay">Show Total Ad Clicks per Day?</label>
         <small id="showTotalAdClicksPerDayHelp" class="form-text text-muted">Whether or not Total Ad Clicks per Day should be shown on reports</small>
       </div>
+      <div class="custom-control custom-checkbox">
+        {{input type="checkbox" checked=model.showTotalUniqueClicks class="custom-control-input" id="showTotalUniqueClicks" aria-describedby="showTotalUniqueClicksHelp"}}
+        <label class="custom-control-label" for="showTotalUniqueClicks">Show Total Unique Clicks?</label>
+        <small id="showTotalUniqueClicksHelp" class="form-text text-muted">Whether or not Total Unique Clicks should be shown on reports</small>
+      </div>
     </div>
 
   </div>

--- a/manage/app/templates/components/email-campaign/metrics-list-item.hbs
+++ b/manage/app/templates/components/email-campaign/metrics-list-item.hbs
@@ -38,6 +38,7 @@
         displayDeliveredMetrics=item.email.displayDeliveredMetrics
         showAdvertiserCTOR=item.showAdvertiserCTOR
         showTotalAdClicksPerDay=item.showTotalAdClicksPerDay
+        showTotalUniqueClicks=item.showTotalUniqueClicks
         deployments=data.deployments
         totals=data.totals
         sortBy=sortBy

--- a/manage/app/templates/components/lead-report/tables/email-metrics.hbs
+++ b/manage/app/templates/components/lead-report/tables/email-metrics.hbs
@@ -18,7 +18,7 @@
     {{#if showTotalAdClicksPerDay}}
       <th>Total Ad Clicks per Day</th>
     {{/if}}
-    {{#if displayTotalUniqueClicks}}
+    {{#if showTotalUniqueClicks}}
       <th>Total Unique Clicks</th>
     {{/if}}
   </tr>
@@ -50,7 +50,7 @@
       {{#if showTotalAdClicksPerDay}}
         <td>{{ format-number row.clicks format="0,0" }}</td>
       {{/if}}
-      {{#if displayTotalUniqueClicks}}
+      {{#if showTotalUniqueClicks}}
         <td>{{ format-number row.identities format="0,0" }}</td>
       {{/if}}
     </tr>
@@ -76,7 +76,7 @@
     {{#if showTotalAdClicksPerDay}}
       <th>{{ format-number totals.clicks format="0,0" }}</th>
     {{/if}}
-    {{#if displayTotalUniqueClicks}}
+    {{#if showTotalUniqueClicks}}
       <th>{{ format-number totals.identities format="0,0" }}</th>
     {{/if}}
   </tr>

--- a/manage/app/templates/lead-report/email/metrics.hbs
+++ b/manage/app/templates/lead-report/email/metrics.hbs
@@ -29,6 +29,7 @@
             displayDeliveredMetrics=campaign.email.displayDeliveredMetrics
             showAdvertiserCTOR=model.campaign.showAdvertiserCTOR
             showTotalAdClicksPerDay=model.campaign.showTotalAdClicksPerDay
+            showTotalUniqueClicks=model.campaign.showTotalUniqueClicks
             deployments=model.deployments
             totals=model.totals
             sortBy=sortBy

--- a/monorepo/services/exports/src/actions/campaign/email-metrics.js
+++ b/monorepo/services/exports/src/actions/campaign/email-metrics.js
@@ -27,6 +27,7 @@ const QUERY = gql`
         id
         showAdvertiserCTOR
         showTotalAdClicksPerDay
+        showTotalUniqueClicks
       }
       deployments {
         identities
@@ -67,6 +68,7 @@ module.exports = async (params = {}, { context }) => {
   const { data } = await apollo.query({ query: QUERY, variables });
   const showAdvertiserCTOR = get(data, 'reportEmailMetrics.campaign.showAdvertiserCTOR');
   const showTotalAdClicksPerDay = get(data, 'reportEmailMetrics.campaign.showTotalAdClicksPerDay');
+  const showTotalUniqueClicks = get(data, 'reportEmailMetrics.campaign.showTotalUniqueClicks');
 
   const rows = getAsArray(data, 'reportEmailMetrics.deployments').map((row) => {
     const { deployment } = row;
@@ -81,7 +83,7 @@ module.exports = async (params = {}, { context }) => {
       CTR: metrics.clickToDeliveredRate * 100,
       ...(showAdvertiserCTOR && { 'Advertiser CTR': row.advertiserClickRate * 100 }),
       ...(showTotalAdClicksPerDay && { 'Total Ad Clicks per Day': row.clicks }),
-      'Total Unique Clicks': row.identities,
+      ...(showTotalUniqueClicks && { 'Total Unique Clicks': row.identities }),
       // 'Preview URL': send.url,
     };
   });

--- a/monorepo/services/server/src/graphql/definitions/campaign.js
+++ b/monorepo/services/server/src/graphql/definitions/campaign.js
@@ -70,6 +70,7 @@ type Campaign {
   updatedAt: Date
   showAdvertiserCTOR: Boolean!
   showTotalAdClicksPerDay: Boolean!
+  showTotalUniqueClicks: Boolean!
 
   gamLineItems(input: CampaignGAMLineItemsInput = {}): GAM_LineItemConnection!
   gamLineItemReport: JSON
@@ -275,6 +276,7 @@ input UpdateCampaignPayloadInput {
   endDate: Date
   showAdvertiserCTOR: Boolean!
   showTotalAdClicksPerDay: Boolean!
+  showTotalUniqueClicks: Boolean!
 }
 
 input UpdateCampaignInput {

--- a/monorepo/services/server/src/graphql/resolvers/campaign.js
+++ b/monorepo/services/server/src/graphql/resolvers/campaign.js
@@ -748,6 +748,7 @@ module.exports = {
         maxIdentities,
         showAdvertiserCTOR,
         showTotalAdClicksPerDay,
+        showTotalUniqueClicks,
       } = payload;
 
       const record = await Campaign.findOne({ _id: id || null, deleted: false });
@@ -761,6 +762,7 @@ module.exports = {
         maxIdentities: calcMax(auth, maxIdentities),
         showAdvertiserCTOR,
         showTotalAdClicksPerDay,
+        showTotalUniqueClicks,
       });
       return record.save();
     },

--- a/monorepo/services/server/src/mongodb/schema/campaign.js
+++ b/monorepo/services/server/src/mongodb/schema/campaign.js
@@ -255,6 +255,11 @@ const schema = new Schema({
     required: true,
     default: true,
   },
+  showTotalUniqueClicks: {
+    type: Boolean,
+    required: true,
+    default: true,
+  },
   email: {
     type: emailSchema,
     default: {},


### PR DESCRIPTION
Toggled off:
![Screenshot from 2023-09-05 10-23-44](https://github.com/parameter1/lead-management/assets/46794001/f7124b58-02f7-4148-8e60-96a19aba9786)
![Screenshot from 2023-09-05 10-24-01](https://github.com/parameter1/lead-management/assets/46794001/b49b0dad-4210-4cb4-b432-a536b3df28f7)

Toggled on:
![Screenshot from 2023-09-05 10-24-19](https://github.com/parameter1/lead-management/assets/46794001/b8025b09-f36a-4a99-9b6f-85b673855b4e)
![Screenshot from 2023-09-05 10-24-29](https://github.com/parameter1/lead-management/assets/46794001/67995d3c-c4a1-4458-b594-ecb726522429)


This will remove the respective column from the reports and exports that include them that have context of the campaign they are apart of.