### PR TITLE
Allow submission of suppressions via file upload (CSV) for campaign

### DIFF
--- a/manage/app/components/campaign-identity-filter.js
+++ b/manage/app/components/campaign-identity-filter.js
@@ -32,5 +32,28 @@ export default Component.extend(FormMixin, {
         };
       }));
     },
+    async appendExclusions(event) {
+      this.startAction()
+      try {
+        event.preventDefault()
+        const data = new FormData(event.target);
+        const r = await fetch('/append-exclusions-to-campaign', {
+          method: 'POST',
+          body: data,
+        });
+        if (!r.ok) {
+          const json = await r.json();
+          if (json && json.message) throw new Error(json.message);
+          throw new Error('A fatal error was encountered')
+        }
+        const jsonResponse = await r.json()
+        this.get('filters').pushObject(jsonResponse);
+        this.send('triggerChange');
+      } catch (e) {
+        this.get('graphErrors').show(e);
+      } finally {
+        this.endAction();
+      }
+    }
   },
 });

--- a/manage/app/components/campaign-identity-filter.js
+++ b/manage/app/components/campaign-identity-filter.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
+import FormMixin from 'leads-manage/mixins/form-mixin';
 import { inject } from '@ember/service';
 
-export default Component.extend({
+export default Component.extend(FormMixin, {
   identityAttributes: inject(),
 
   title: 'Exclude Leads Where...',

--- a/manage/app/templates/components/campaign-identity-filter.hbs
+++ b/manage/app/templates/components/campaign-identity-filter.hbs
@@ -25,7 +25,7 @@
       <div class="form-group">
         <label for="csv-file">Upload Email Exclusions as CSV</label>
         <input class="form-control" name="file" type="file" id="csv-file" accept="text/csv" disabled={{isActionRunning}} required>
-        <small>Uploaded CSV should contain 1 column with title of Suppress whose respective rows contain individual emails or email domains to suppress/exclude</small>
+        <small>Uploaded CSV should contain 1 column with title of Suppress whose respective rows contain individual emails or email domains to suppress/exclude.</small>
       </div>
       <button type="submit" class="btn btn-success" disabled={{isActionRunning}}>
         Append Uploaded Email Exclusions

--- a/manage/app/templates/components/campaign-identity-filter.hbs
+++ b/manage/app/templates/components/campaign-identity-filter.hbs
@@ -25,7 +25,7 @@
       <div class="form-group">
         <label for="csv-file">Upload Email Exclusions as CSV</label>
         <input class="form-control" name="file" type="file" id="csv-file" accept="text/csv" disabled={{isActionRunning}} required>
-        <small>Uploaded CSV should contain 1 column with title of Suppress those respective rows contain individual emails or email domains to suppress/exclude</small>
+        <small>Uploaded CSV should contain 1 column with title of Suppress whose respective rows contain individual emails or email domains to suppress/exclude</small>
       </div>
       <button type="submit" class="btn btn-success" disabled={{isActionRunning}}>
         Append Uploaded Email Exclusions

--- a/manage/app/templates/components/campaign-identity-filter.hbs
+++ b/manage/app/templates/components/campaign-identity-filter.hbs
@@ -23,11 +23,12 @@
     </div>
     <form enctype="multipart/form-data" onsubmit={{action "appendExclusions"}}>
       <div class="form-group">
-        <label for="csv-file">Upload Exclusions as CSV</label>
+        <label for="csv-file">Upload Email Exclusions as CSV</label>
         <input class="form-control" name="file" type="file" id="csv-file" accept="text/csv" disabled={{isActionRunning}} required>
+        <small>Uploaded CSV should contain 1 column with title of Suppress those respective rows contain individual emails or email domains to suppress/exclude</small>
       </div>
       <button type="submit" class="btn btn-success" disabled={{isActionRunning}}>
-        Append Uploaded Exclusions
+        Append Uploaded Email Exclusions
       </button>
     </form>
   </div>

--- a/manage/app/templates/components/campaign-identity-filter.hbs
+++ b/manage/app/templates/components/campaign-identity-filter.hbs
@@ -21,12 +21,12 @@
         <a class="dropdown-item" href="javascript:void(0);" {{action "addFilter" field}}>{{ field.label }}</a>
       {{/each}}
     </div>
-    <form enctype="multipart/form-data">
+    <form enctype="multipart/form-data" onsubmit={{action "appendExclusions"}}>
       <div class="form-group">
         <label for="csv-file">Upload Exclusions as CSV</label>
-        <input class="form-control" name="file" type="file" id="csv-file" accept="text/csv" required>
+        <input class="form-control" name="file" type="file" id="csv-file" accept="text/csv" disabled={{isActionRunning}} required>
       </div>
-      <button type="submit" class="btn btn-success">
+      <button type="submit" class="btn btn-success" disabled={{isActionRunning}}>
         Append Uploaded Exclusions
       </button>
     </form>

--- a/manage/app/templates/components/campaign-identity-filter.hbs
+++ b/manage/app/templates/components/campaign-identity-filter.hbs
@@ -21,6 +21,14 @@
         <a class="dropdown-item" href="javascript:void(0);" {{action "addFilter" field}}>{{ field.label }}</a>
       {{/each}}
     </div>
+    <form enctype="multipart/form-data">
+      <div class="form-group">
+        <label for="csv-file">Upload Exclusions as CSV</label>
+        <input class="form-control" name="file" type="file" id="csv-file" accept="text/csv" required>
+      </div>
+      <button type="submit" class="btn btn-success">
+        Append Uploaded Exclusions
+      </button>
+    </form>
   </div>
 </div>
-

--- a/monorepo/services/server/src/routes/append-exclusions-to-campaign.js
+++ b/monorepo/services/server/src/routes/append-exclusions-to-campaign.js
@@ -1,0 +1,58 @@
+const { Router } = require('express');
+const multer = require('multer');
+const csvToJson = require('csvtojson');
+const createError = require('http-errors');
+const slug = require('slug');
+const asyncRoute = require('../utils/async-route');
+
+const router = Router();
+const dev = process.env.NODE_ENV === 'development';
+
+const storage = multer.diskStorage({
+  filename: (_, file, cb) => {
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1E9)}`;
+    cb(null, `${file.fieldname}-${uniqueSuffix}`);
+  },
+});
+const upload = multer({ storage });
+
+router.post('/', upload.single('file'), asyncRoute(async (req, res) => {
+  const { file } = req;
+
+  const rows = await csvToJson().fromFile(file.path);
+  if (!rows || !rows.length) throw createError(400, 'Unable to find any rows in the provided file.');
+
+  let fieldName;
+  Object.keys(rows[0]).forEach((k) => {
+    const cleaned = slug(k.trim()).replace(/-/g, '');
+    if (/^suppress/.test(cleaned)) {
+      if (fieldName) throw createError(400, 'More than one suppress column was found the provided file.');
+      fieldName = k;
+    }
+  });
+  if (!fieldName) throw createError(400, 'Unable to find a suppress column in the provided file.');
+  const suppressions = rows.reduce((set, row) => {
+    const value = row[fieldName].trim().toLowerCase();
+    if (value) set.add(value);
+    return set;
+  }, new Set());
+
+  res.header('content-type', 'application/json');
+  res.send(JSON.stringify({
+    key: 'emailAddress',
+    label: 'Email',
+    matchType: 'contains',
+    terms: Array.from(suppressions),
+  }));
+}));
+
+// eslint-disable-next-line no-unused-vars
+router.use((err, req, res, next) => {
+  const { message, stack } = err;
+  const status = err.statusCode || err.status || 500;
+  const obj = { error: true, status, message };
+  if (dev && stack) obj.stack = stack.split('\n');
+  res.status(status).json(obj);
+});
+
+module.exports = router;

--- a/monorepo/services/server/src/routes/index.js
+++ b/monorepo/services/server/src/routes/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const asyncRoute = require('../utils/async-route');
 
 const appendLeadData = require('./append-lead-data-to-csv');
+const appendExclusionsToCampaign = require('./append-exclusions-to-campaign');
 const creative = require('./creative');
 const exactTargetEmails = require('./exact-target-email-export');
 const exportData = require('./exports');
@@ -10,6 +11,7 @@ const { OmedaEmailDeploymentHtml } = require('../mongodb/models');
 
 module.exports = (app) => {
   app.use('/append-lead-data-to-csv', appendLeadData);
+  app.use('/append-exclusions-to-campaign', appendExclusionsToCampaign);
   app.use('/creative', creative);
   app.get('/email-deployment-html/:entity', asyncRoute(async (req, res) => {
     const { $tenant } = req;


### PR DESCRIPTION
Follows a similar design pattern to the components utilizing the endpoint/route defined here: https://github.com/parameter1/lead-management/blob/main/monorepo/services/server/src/routes/append-lead-data-to-csv.js

![Screenshot from 2023-10-30 12-15-12](https://github.com/parameter1/lead-management/assets/46794001/7b449ef5-4878-4708-95db-ef456242d4a8)
![image](https://github.com/parameter1/lead-management/assets/46794001/94dc587c-74db-4d8c-972f-8971d5f2718a)
(Showing temporary addition of suppression criteria given uploaded list)
![Screenshot from 2023-10-24 09-51-02](https://github.com/parameter1/lead-management/assets/46794001/45575f1f-1fb3-4875-be41-cdf167a717fc)


By default when a list is uploaded it will default to the `Email` field using the `contains` matcher.