### PR TITLE
Include Lynch Media demographic IDs in `demoMap`

### DIFF
--- a/monorepo/packages/lambda/test/process-customers.js
+++ b/monorepo/packages/lambda/test/process-customers.js
@@ -5,5 +5,6 @@ handler({
     { body: JSON.stringify({ tenantKey: 'indm', encryptedCustomerId: '2804I4421578C9G' }) },
     { body: JSON.stringify({ tenantKey: 'indm', encryptedCustomerId: '2804I4421578C9G' }) },
     { body: JSON.stringify({ tenantKey: 'indm', encryptedCustomerId: '8797H3317467C8C' }) },
+    { body: JSON.stringify({ tenantKey: 'lynchm', encryptedCustomerId: '4357B1923823E9X' }) },
   ],
 }).catch((e) => setImmediate(() => { throw e; }));

--- a/monorepo/packages/sync/ops/transform-customer.js
+++ b/monorepo/packages/sync/ops/transform-customer.js
@@ -11,6 +11,8 @@ const getFieldCount = (obj) => Object.keys(obj).filter((k) => obj[k]).length;
 const demoMap = new Map([
   [85, 'Industry'],
   [86, 'Job Function'],
+  [105, 'Industry'],
+  [106, 'Job Function'],
 ]);
 
 /**

--- a/monorepo/packages/sync/test/commands/upsert-customers.js
+++ b/monorepo/packages/sync/test/commands/upsert-customers.js
@@ -1,11 +1,7 @@
 const run = require('../_run');
 const command = require('../../commands/upsert-customers');
 
-async function multiTenantRun() {
-  return Promise.all([
-    command({ tenantKey: 'indm', encryptedCustomerIds: ['8797H3317467C8C', '5689J2201356C7J'] }),
-    command({ tenantKey: 'lynchm', encryptedCustomerIds: ['4357B1923823E9X'] }),
-  ]);
-}
-
-run(multiTenantRun).catch((e) => setImmediate(() => { throw e; }));
+run(() => Promise.all([
+  command({ tenantKey: 'indm', encryptedCustomerIds: ['8797H3317467C8C', '5689J2201356C7J'] }),
+  command({ tenantKey: 'lynchm', encryptedCustomerIds: ['4357B1923823E9X'] }),
+])).catch((e) => setImmediate(() => { throw e; }));

--- a/monorepo/packages/sync/test/commands/upsert-customers.js
+++ b/monorepo/packages/sync/test/commands/upsert-customers.js
@@ -2,7 +2,7 @@ const run = require('../_run');
 const command = require('../../commands/upsert-customers');
 
 async function multiTenantRun() {
-  await Promise.all([
+  return Promise.all([
     command({ tenantKey: 'indm', encryptedCustomerIds: ['8797H3317467C8C', '5689J2201356C7J'] }),
     command({ tenantKey: 'lynchm', encryptedCustomerIds: ['4357B1923823E9X'] }),
   ]);

--- a/monorepo/packages/sync/test/commands/upsert-customers.js
+++ b/monorepo/packages/sync/test/commands/upsert-customers.js
@@ -1,5 +1,11 @@
 const run = require('../_run');
 const command = require('../../commands/upsert-customers');
 
-run(command, { tenantKey: 'indm', encryptedCustomerIds: ['8797H3317467C8C', '5689J2201356C7J'] })
-  .catch((e) => setImmediate(() => { throw e; }));
+async function multiTenantRun() {
+  await Promise.all([
+    command({ tenantKey: 'indm', encryptedCustomerIds: ['8797H3317467C8C', '5689J2201356C7J'] }),
+    command({ tenantKey: 'lynchm', encryptedCustomerIds: ['4357B1923823E9X'] }),
+  ]);
+}
+
+run(multiTenantRun).catch((e) => setImmediate(() => { throw e; }));


### PR DESCRIPTION
Confirmation that the additions to the `demoMap` apply to appropriate users:
![image](https://github.com/parameter1/lead-management/assets/46794001/38499c8a-75c4-4a87-8deb-1d7d63a22ae8)
