### PR TITLE
Remove apple.com from publicDomains (allows for limiting to at most 2)

### DIFF
--- a/monorepo/services/server/src/services/email-report.js
+++ b/monorepo/services/server/src/services/email-report.js
@@ -205,7 +205,6 @@ module.exports = {
   getEmailDomainAggregationStages() {
     const publicDomains = [
       'aol.com',
-      'apple.com',
       'att.net',
       'bellsouth.net',
       'comcast.net',


### PR DESCRIPTION
Validated this indeed reduces the number of apple.com domain emails to 2.